### PR TITLE
Pick shell fragments per OS so iexec runs on Windows

### DIFF
--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -44,3 +44,31 @@ jobs:
           folder: build/gh-pages
           clean: true
         if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-24.04'
+  windows:
+    timeout-minutes: 15
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v7
+      - shell: bash
+        run: sed -E 's/^(hard|soft)[[:space:]]+//' DEPENDS.txt > .texlive-packages.txt
+      - uses: zauguin/install-texlive@v4.4.0
+        with:
+          package_file: .texlive-packages.txt
+          texlive_version: 2025
+      - name: Check that iexec runs on Windows via cmd.exe
+        shell: bash
+        run: |
+          l3build unpack
+          cp build/unpacked/iexec.sty .
+          cat > win-smoke.tex <<'EOF'
+          \documentclass{article}
+          \usepackage{iexec}
+          \begin{document}
+          \iexec[quiet]{echo hello}
+          \iexec[null]{echo hello}
+          \iexec[quiet,ignore]{this-command-does-not-exist}
+          Rendered by \iexec{echo cross-platform}.
+          \end{document}
+          EOF
+          pdflatex -interaction=nonstopmode -halt-on-error -shell-escape win-smoke.tex
+          test -f win-smoke.pdf

--- a/iexec.dtx
+++ b/iexec.dtx
@@ -222,7 +222,8 @@ Today is \iexec{date +\%Y}!
 %\fi
 
 % \DescribeMacro{null}
-% The ``stdout'' of the command is redirected to ``|/dev/null|'':
+% The ``stdout'' of the command is redirected to ``|/dev/null|''
+% (or to ``|NUL|'' on Windows):
 %\iffalse
 %<*verb>
 %\fi
@@ -326,6 +327,27 @@ Today is \iexec{date +\%Y}!
 %    \end{macrocode}
 % \end{macro}
 
+% Then, we detect the operating system, because a few shell fragments
+% differ between Windows and Unix: the null device (|/dev/null| versus
+% |NUL|), the file removal command (|rm| versus |del|), and the way the
+% exit code of the command is captured.
+% \changes{0.16.0}{2026/07/10}{The package now works on Windows too, not only on Unix, because the shell fragments are chosen depending on the operating system.}
+%    \begin{macrocode}
+\makeatletter
+\newif\ifiexec@windows
+\ExplSyntaxOn
+\sys_if_platform_windows:TF{\iexec@windowstrue}{\iexec@windowsfalse}
+\ExplSyntaxOff
+\ifiexec@windows
+  \def\iexec@devnull{NUL}
+  \def\iexec@rm{del}
+\else
+  \def\iexec@devnull{/dev/null}
+  \def\iexec@rm{rm}
+\fi
+\makeatother
+%    \end{macrocode}
+
 % \begin{macro}{\iexec}
 % Then, we define |\iexec| command.
 % It is implemented with the help of |\ShellEscape| from |shellesc| package:
@@ -374,9 +396,13 @@ Today is \iexec{date +\%Y}!
 %    \begin{macrocode}
         \def\iexec@cmd{(#2)
           \ifdefined\iexec@append>\fi>
-          \ifdefined\iexec@null/dev/null\else\iexec@stdout\fi
-          \space\ifdefined\iexec@stderr2>\iexec@stderr\else2>&1\fi;
-          /bin/echo -n \string$?\% >\iexec@exit}%
+          \ifdefined\iexec@null\iexec@devnull\else\iexec@stdout\fi
+          \space\ifdefined\iexec@stderr2>\iexec@stderr\else2>&1\fi%
+          \ifiexec@windows%
+            \space&&\space(echo 0)>\iexec@exit\space||\space(echo 1)>\iexec@exit%
+          \else%
+            ;\space/bin/echo -n \string$?\% >\iexec@exit%
+          \fi}%
         \ShellEscape{\iexec@cmd}%
 %    \end{macrocode}
 % Then, a message is printed to \TeX{} log:
@@ -476,11 +502,11 @@ Today is \iexec{date +\%Y}!
             were not deleted^^J}%
           \fi%
         \else%
-          \ShellEscape{rm \iexec@stdout}%
+          \ShellEscape{\iexec@rm\space\iexec@stdout}%
           \ifdefined\iexec@log%
             \message{iexec: The file '\iexec@stdout' was deleted^^J}%
           \fi%
-          \ShellEscape{rm \iexec@exit}%
+          \ShellEscape{\iexec@rm\space\iexec@exit}%
           \ifdefined\iexec@log%
             \message{iexec: The file '\iexec@exit' was deleted^^J}%
           \fi%


### PR DESCRIPTION
The command wrapper in `iexec.dtx` picked its shell fragments from a fixed POSIX vocabulary: it sent stdout to `/dev/null`, chained the exit-code capture with `;`, ran `/bin/echo -n $?`, and cleaned up with `rm`. None of that parses under `cmd.exe`, so `\iexec` was broken on Windows no matter what command you passed it. This change detects the platform once (through expl3's `\sys_if_platform_windows:`, which iexec already pulls in, so no new dependency) and swaps in `NUL`, a `&& (echo 0) || (echo 1)` exit capture, and `del` on Windows. The Unix command comes out byte-for-byte identical, so nothing changes for existing users.

The motivation is downstream: [docshots](https://github.com/yegor256/docshots) runs every one of its shell calls through `\iexec`, so it could never work on Windows while this wrapper stayed Unix-only (see yegor256/docshots#62). Fixing it here unblocks that.

One thing for the reviewer: I have no Windows box, so the Unix branch is verified locally (`l3build ctan` stays green) and the Windows branch is verified two ways — its semantics were exercised on POSIX sh, which shares the `&&`/`||`/`()` behaviour, and a new CI job compiles an `\iexec` document on a Windows runner through cmd.exe. The `del` cleanup still assumes slash-free temp paths, which is fine for iexec's own defaults; callers that set slashed `stdout`/`exit` paths on Windows are a separate follow-up.

Closes #86
