### PR TITLE
Show file size for luatex and xetex

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -11,6 +11,7 @@ soft l3build
 soft lm
 soft microtype
 soft minted
+soft pdftexcmds
 soft pgf
 soft pgfopts
 soft scheme-basic

--- a/iexec.dtx
+++ b/iexec.dtx
@@ -271,6 +271,15 @@ Today is \iexec{date +\%Y}!
 \RequirePackage{shellesc}
 %    \end{macrocode}
 
+% Then, we include the \href{https://ctan.org/pkg/pdftexcmds}{pdftexcmds} package, which
+% provides |\pdf@filesize|, working uniformly across \texttt{pdftex},
+% \texttt{luatex}, and \texttt{xetex} (the |\pdffilesize| primitive exists in
+% \texttt{pdftex} only):
+% \changes{0.16.1}{2026/07/10}{The file size is now printed to the log under \texttt{luatex} and \texttt{xetex} too, not only \texttt{pdftex}, because we use \texttt{\char`\\pdf@filesize} from \texttt{pdftexcmds} instead of the \texttt{\char`\\pdffilesize} primitive.}
+%    \begin{macrocode}
+\RequirePackage{pdftexcmds}
+%    \end{macrocode}
+
 % Then, we parse package options, with the help
 % of \href{https://ctan.org/pkg/pgfopts}{pgfopts}:
 % \changes{0.14.0}{2024/01/14}{The \texttt{xkeyval} package is not used anymore. Instead, we use \texttt{pgfopts} in order to parse package options.}
@@ -428,8 +437,8 @@ Today is \iexec{date +\%Y}!
           {\PackageError{iexec}{The "\iexec@stdout" file is absent
             after processing, looks like some internal error}{}}%
         \ifdefined\iexec@log%
-          \message{iexec: This is the content of '\iexec@stdout'\ifdefined\pdffilesize
-            \space(\pdffilesize{\iexec@stdout} bytes)\else\fi:^^J}%
+          \message{iexec: This is the content of '\iexec@stdout'%
+            \space(\pdf@filesize{\iexec@stdout} bytes):^^J}%
           \IfFileExists
             {\iexec@stdout}
             {\iexec@typeout{\iexec@stdout}}
@@ -439,8 +448,8 @@ Today is \iexec{date +\%Y}!
         \else%
           \ifnum\iexec@code=0\else%
             \ifdefined\iexec@ignore\else%
-              \message{iexec: See the content of '\iexec@stdout'\ifdefined\pdffilesize
-                \space(\pdffilesize{\iexec@stdout} bytes)\fi
+              \message{iexec: See the content of '\iexec@stdout'%
+                \space(\pdf@filesize{\iexec@stdout} bytes)
                 after failure:^^J}%
               \iexec@typeout{\iexec@stdout}%
               \message{<EOF>^^J}%
@@ -470,14 +479,12 @@ Today is \iexec{date +\%Y}!
         \ifdefined\iexec@log%
           \message{iexec: Due to 'quiet' option we didn't read
           the content of '\iexec@stdout'
-          \ifdefined\pdffilesize (\pdffilesize{\iexec@stdout}
-          bytes)\fi^^J}%
+          (\pdf@filesize{\iexec@stdout} bytes)^^J}%
         \fi%
       \else%
         \ifdefined\iexec@log%
           \message{iexec: We are going to include the content of
-          '\iexec@stdout'\ifdefined\pdffilesize (\pdffilesize
-          {\iexec@stdout} bytes)\fi...^^J}%
+          '\iexec@stdout'(\pdf@filesize{\iexec@stdout} bytes)...^^J}%
         \fi%
         \input{\iexec@stdout}%
         \ifdefined\iexec@unskip\unskip\fi%

--- a/testfiles/simple.luatex.tlg
+++ b/testfiles/simple.luatex.tlg
@@ -28,10 +28,10 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((echo "hello_world") > underscore.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo "hello_world") > underscore.txt 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'underscore.txt':
+iexec: This is the content of 'underscore.txt' (12 bytes):
 hello_world
 <EOF>
-iexec: Due to 'quiet' option we didn't read the content of 'underscore.txt' 
+iexec: Due to 'quiet' option we didn't read the content of 'underscore.txt' (12 bytes)
 iexec: Due to 'trace' package option, the files 'underscore.txt' and 'iexec.ret' were not deleted
 runsystem((echo $ABSENT_VARIABLE) > foo.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 (foo.txt) iexec: The content of 'foo.txt' was included into the document
@@ -52,10 +52,10 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((echo 5) > a.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo 5) > a.txt 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'a.txt':
+iexec: This is the content of 'a.txt' (2 bytes):
 5
 <EOF>
-iexec: Due to 'quiet' option we didn't read the content of 'a.txt' 
+iexec: Due to 'quiet' option we didn't read the content of 'a.txt' (2 bytes)
 iexec: Due to 'trace' package option, the files 'a.txt' and 'iexec.ret' were not deleted
 runsystem((echo 6) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 \foo=\read...
@@ -68,10 +68,10 @@ runsystem(rm iexec.ret)...executed.
 runsystem((date) > /dev/null 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem((echo 'Hello, \LaTeX!') > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo 'Hello, \LaTeX!') > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'iexec.tmp':
+iexec: This is the content of 'iexec.tmp' (15 bytes):
 Hello, \LaTeX!
 <EOF>
-iexec: We are going to include the content of 'iexec.tmp'...
+iexec: We are going to include the content of 'iexec.tmp'(15 bytes)...
 (iexec.tmp) iexec: The content of 'iexec.tmp' was included into the document
 runsystem(rm iexec.tmp)...executed.
 iexec: The file 'iexec.tmp' was deleted

--- a/testfiles/simple.xetex.tlg
+++ b/testfiles/simple.xetex.tlg
@@ -28,10 +28,10 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((echo "hello_world") > underscore.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo "hello_world") > underscore.txt 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'underscore.txt':
+iexec: This is the content of 'underscore.txt' (12 bytes):
 hello_world
 <EOF>
-iexec: Due to 'quiet' option we didn't read the content of 'underscore.txt' 
+iexec: Due to 'quiet' option we didn't read the content of 'underscore.txt' (12 bytes)
 iexec: Due to 'trace' package option, the files 'underscore.txt' and 'iexec.ret' were not deleted
 runsystem((echo $ABSENT_VARIABLE) > foo.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 (foo.txt) iexec: The content of 'foo.txt' was included into the document
@@ -52,10 +52,10 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((echo 5) > a.txt 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo 5) > a.txt 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'a.txt':
+iexec: This is the content of 'a.txt' (2 bytes):
 5
 <EOF>
-iexec: Due to 'quiet' option we didn't read the content of 'a.txt' 
+iexec: Due to 'quiet' option we didn't read the content of 'a.txt' (2 bytes)
 iexec: Due to 'trace' package option, the files 'a.txt' and 'iexec.ret' were not deleted
 runsystem((echo 6) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 \foo=\read...
@@ -68,10 +68,10 @@ runsystem(rm iexec.ret)...executed.
 runsystem((date) > /dev/null 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem((echo 'Hello, \LaTeX!') > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 iexec: [(echo 'Hello, \LaTeX!') > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret]
-iexec: This is the content of 'iexec.tmp':
+iexec: This is the content of 'iexec.tmp' (15 bytes):
 Hello, \LaTeX!
 <EOF>
-iexec: We are going to include the content of 'iexec.tmp'...
+iexec: We are going to include the content of 'iexec.tmp'(15 bytes)...
 (iexec.tmp) iexec: The content of 'iexec.tmp' was included into the document
 runsystem(rm iexec.tmp)...executed.
 iexec: The file 'iexec.tmp' was deleted


### PR DESCRIPTION
The stdout byte size printed to the TeX log now shows up under luatex and xetex, not only pdftex. The package used the `\pdffilesize` primitive, which exists in pdftex alone, so on the other two engines the size was silently dropped. This switches to `\pdf@filesize` from pdftexcmds, which resolves to the right mechanism on each engine.

Issue #59 pointed this out. The pdftex output stays byte-for-byte the same; luatex and xetex now match it, so all three `.tlg` files are identical again. I also added pdftexcmds to `DEPENDS.txt` so CI installs it.

Closes #59