### PR TITLE
Isolate cd from exit-code capture on Windows

### DIFF
--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           l3build unpack
           cp build/unpacked/iexec.sty .
+          mkdir sub
           cat > win-smoke.tex <<'EOF'
           \documentclass{article}
           \usepackage{iexec}
@@ -67,6 +68,7 @@ jobs:
           \iexec[quiet]{echo hello}
           \iexec[null]{echo hello}
           \iexec[quiet,ignore]{this-command-does-not-exist}
+          \iexec[quiet]{cd sub && echo inside}
           Rendered by \iexec{echo cross-platform}.
           \end{document}
           EOF

--- a/iexec.dtx
+++ b/iexec.dtx
@@ -402,8 +402,14 @@ Today is \iexec{date +\%Y}!
 % \changes{0.11.1}{2022/10/23}{When exit code is printed to the file, we add percentchar at the end of line in order to avoid extra space when reading it back.}
 % \changes{0.11.3}{2022/10/29}{Bug fixed, because of which we had an extra leading space.}
 % \changes{0.11.4}{2022/11/01}{In this version we escape dollar sign with \texttt{\char`\\string} command.}
+% \changes{0.16.2}{2026/07/13}{On Windows, the user command is wrapped in \texttt{cmd /c "..."}, so that a \texttt{cd} inside it stays in a child process and doesn't leak into the exit-code capture that follows.}
+% On Windows, |cmd.exe| parentheses are not a subshell, so a |cd| inside
+% the user's command would leak out and make the trailing exit-code echo
+% resolve its file against the changed directory; therefore, on Windows we
+% run the command through a nested |cmd /c "..."|, keeping its directory
+% change isolated (on Unix the |(...)| subshell already does this):
 %    \begin{macrocode}
-        \def\iexec@cmd{(#2)
+        \def\iexec@cmd{\ifiexec@windows cmd\space/c\space"(#2)"\else(#2)\fi\space
           \ifdefined\iexec@append>\fi>
           \ifdefined\iexec@null\iexec@devnull\else\iexec@stdout\fi
           \space\ifdefined\iexec@stderr2>\iexec@stderr\else2>&1\fi%


### PR DESCRIPTION
On Windows the exit-code capture broke whenever the user command changed the working directory, for example `\iexec{cd sub && prog}`. The command now runs through a nested `cmd /c "(...)"`, so its `cd` stays inside a child process and the trailing `(echo 0)>iexec.ret` / `(echo 1)>iexec.ret` resolves against the original directory again.

The root cause is that `cmd.exe` parentheses are not a subshell, unlike POSIX `sh`, so a `cd` inside the group leaked out and made the exit file land in the wrong directory; iexec then failed to read it back and aborted the build. The Unix branch is untouched, so its behaviour and the regression logs stay byte-for-byte identical.

I also added a `cd sub && echo inside` case to the Windows smoke test in CI, which reproduces the failure on `windows-2025`.

Closes #90